### PR TITLE
SSH to gitpod and local remote machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,5 +160,6 @@ EXPOSE 6080-6090
 
 USER $USER
 RUN code --install-extension github.copilot
+RUN code --install-extension ms-vscode-remote.remote-ssh
 
 ENTRYPOINT ["/bin/sh", "-c", "set -o errexit; case \"$1\" in sh|bash) set -- \"$@\" ;; *) set -- sway ;; esac; exec \"$@\"", "--"]

--- a/config/sway/gitpod_ssh.py
+++ b/config/sway/gitpod_ssh.py
@@ -1,0 +1,10 @@
+import os
+import subprocess
+
+gitpod = os.getenv("GITPOD_SSH_CMD")
+
+if gitpod is not None:
+    subprocess.run([gitpod], shell=True)
+
+else:
+    print("Environment variables for Gitpod command not set")

--- a/config/sway/local_ssh.py
+++ b/config/sway/local_ssh.py
@@ -1,0 +1,13 @@
+import os
+import subprocess
+
+port = os.getenv("SSH_PORT")
+user = os.getenv("SSH_USER")
+ngrok_num = os.getenv("SSH_NGROK_NUM")
+
+if port is not None and user is not None and ngrok_num is not None:
+    command = 'ssh -p ' + port + ' ' + user + '@' + ngrok_num +'.tcp.ngrok.io'
+    subprocess.run([command], shell=True)
+
+else:
+    print("Environment variables for locall ssh are not set")


### PR DESCRIPTION
These scripts will allow users to easily ssh into their machines. This is useful as a user is used to his workspace and would want to switch to aither for multi-user sharing purposes. 

A user can run the scripts local_ssh.py or gitpod_ssh.py at anytime as long as the right environment variables are set.

So far the environment variables that need to be set are the following:
Local SSH: port, user, ngrok_number
Gitpod SSH: SSH command retrievable from gitpod